### PR TITLE
Fixed issue #15 regarding the concatenation of unicode objects.

### DIFF
--- a/pipe.py
+++ b/pipe.py
@@ -514,10 +514,11 @@ def traverse(args):
 
 @Pipe
 def concat(iterable, separator=", "):
-    try : 
-        return separator.join(map(unicode,iterable))
-    except UnicodeDecodeError:
-        return separator.join(map(str,iterable))
+    try:
+        return separator.join(map(str,iterable))        
+    except UnicodeEncodeError:
+        # in case it's unicode no mapping is required.
+        return separator.join(iterable)
 
 @Pipe
 def as_list(iterable):


### PR DESCRIPTION
Solution was to first try map(unicode,iterable) and if that fails try map(str,iterable) instead.
