### PR TITLE
append docstring of wrapped func to instance's

### DIFF
--- a/pipe.py
+++ b/pipe.py
@@ -127,7 +127,7 @@ add
     21
 
 first
-    Returns the first element of the given iterable
+    Returns the first element of the given iterable, return the default value if no
     >>> (1, 2, 3, 4, 5, 6) | first
     1
 
@@ -554,8 +554,11 @@ def add(x):
     return sum(x)
 
 @Pipe
-def first(iterable):
-    return next(iter(iterable))
+def first(iterable, default=None):
+    try:
+        return next(iter(iterable))
+    except StopIteration:
+        return default
 
 @Pipe
 def chain(iterable):

--- a/pipe.py
+++ b/pipe.py
@@ -378,7 +378,7 @@ __all__ = [
     'tee', 'add', 'first', 'chain', 'select', 'where', 'take_while',
     'skip_while', 'aggregate', 'groupby', 'sort', 'reverse',
     'chain_with', 'islice', 'izip', 'passed', 'index', 'strip', 
-    'lstrip', 'rstrip', 'run_with', 't', 'to_type',
+    'lstrip', 'rstrip', 'run_with', 't', 'to_type', 'as_set',
 ]
 
 class Pipe:

--- a/pipe.py
+++ b/pipe.py
@@ -85,6 +85,11 @@ as_dict
     [('a', 1), ('b', 2), ('c', 3)] | as_dict
     {'a': 1, 'b': 2, 'c': 3}
 
+as_set
+    Outputs an iterable of tuples as a set
+    >>> [1, 2, 2] | as_set
+    (1, 2)
+    
 concat()
     Aggregates strings using given separator, or ", " by default
     >>> [1, 2, 3, 4] | concat
@@ -525,6 +530,10 @@ def as_list(iterable):
 @Pipe
 def as_tuple(iterable):
     return tuple(iterable)
+
+@Pipe
+def as_set(iterable):
+    return set(iterable)
 
 @Pipe
 def stdout(x):

--- a/pipe.py
+++ b/pipe.py
@@ -410,7 +410,7 @@ class Pipe:
         return Pipe(lambda x: self.function(x, *args, **kwargs))
 
 @Pipe
-def take(iterable, qte):
+def take(iterable, qte=1):
     "Yield qte of elements in the given iterable."
     for item in iterable:
         if qte > 0:
@@ -420,7 +420,7 @@ def take(iterable, qte):
             return
 
 @Pipe
-def tail(iterable, qte):
+def tail(iterable, qte=1):
     "Yield qte of elements in the given iterable."
     out = []
     for item in iterable:
@@ -430,7 +430,7 @@ def tail(iterable, qte):
     return out
         
 @Pipe
-def skip(iterable, qte):
+def skip(iterable, qte=1):
     "Skip qte elements in the given iterable, then yield others."
     for item in iterable:
         if qte == 0:

--- a/pipe.py
+++ b/pipe.py
@@ -395,6 +395,8 @@ class Pipe:
     """
     def __init__(self, function):
         self.function = function
+        self.__doc__ = function.__doc__ or ''
+
 
     def __ror__(self, other):
         return self.function(other)

--- a/pipe.py
+++ b/pipe.py
@@ -88,7 +88,7 @@ as_dict
 as_set
     Outputs an iterable of tuples as a set
     >>> [1, 2, 2] | as_set
-    (1, 2)
+    set([1, 2])
     
 concat()
     Aggregates strings using given separator, or ", " by default
@@ -378,7 +378,8 @@ __all__ = [
     'tee', 'add', 'first', 'chain', 'select', 'where', 'take_while',
     'skip_while', 'aggregate', 'groupby', 'sort', 'reverse',
     'chain_with', 'islice', 'izip', 'passed', 'index', 'strip', 
-    'lstrip', 'rstrip', 'run_with', 't', 'to_type', 'as_set',
+    'lstrip', 'rstrip', 'run_with', 't', 'to_type', 'as_set', 'last',
+    'clone',
 ]
 
 class Pipe:
@@ -401,7 +402,6 @@ class Pipe:
     def __init__(self, function):
         self.function = function
         self.__doc__ = function.__doc__ or ''
-
 
     def __ror__(self, other):
         return self.function(other)
@@ -482,6 +482,10 @@ def as_dict(iterable):
     return dict(iterable)
 
 @Pipe
+def as_set(iterable):
+    return set(iterable)
+
+@Pipe
 def permutations(iterable, r=None):
     # permutations('ABCD', 2) --> AB AC AD BA BC BD CA CB CD DA DB DC
     # permutations(range(3)) --> 012 021 102 120 201 210
@@ -532,10 +536,6 @@ def as_tuple(iterable):
     return tuple(iterable)
 
 @Pipe
-def as_set(iterable):
-    return set(iterable)
-
-@Pipe
 def stdout(x):
     sys.stdout.write(str(x))
 
@@ -559,6 +559,14 @@ def first(iterable, default=None):
         return next(iter(iterable))
     except StopIteration:
         return default
+
+@Pipe
+def last(iterable, default=None):
+    "Yield last element in the given iterable."
+    latest = default
+    for item in iterable:
+        latest = item
+    return latest
 
 @Pipe
 def chain(iterable):
@@ -637,6 +645,7 @@ def to_type(x, t):
 
 chain_with = Pipe(itertools.chain)
 islice = Pipe(itertools.islice)
+clone = Pipe(itertools.tee)
 
 # Python 2 & 3 compatibility
 if "izip" in dir(itertools):


### PR DESCRIPTION
## below is snapshots in ipython

In [2]: take?
Type:            instance
Base Class:      pipe.Pipe
String form:     <pipe.Pipe instance at 0x10efae830>
File:            /Library/Python/2.7/site-packages/pipe.py
**Docstring:**       Yield qte of elements in the given iterable.
**Class docstring:**
Represent a Pipeable Element :
Described as :
first = Pipe(lambda iterable: next(iter(iterable)))
and used as :
print [1, 2, 3] | first
printing 1

Or represent a Pipeable Function :
It's a function returning a Pipe
Described as :
select = Pipe(lambda iterable, pred: (pred(x) for x in iterable))
and used as :
print [1, 2, 3] | select(lambda x: x \* 2)
