### PR TITLE
Add dedup

### DIFF
--- a/pipe.py
+++ b/pipe.py
@@ -90,6 +90,16 @@ def skip(iterable, qte):
         else:
             qte -= 1
 
+@Pipe
+def dedup(iterable):
+    """Only yield unique items. Rely on __hash__ of the item type to find duplication."""
+    seen = set()
+    for item in iterable:
+        if item in seen:
+            continue
+        else:
+            seen.add(item)
+            yield item
 
 @Pipe
 def all(iterable, pred):


### PR DESCRIPTION
I added a dedup function because this can be useful in many situations. (can also be called `uniq` in keeping with the `sh` theme)