### PR TITLE
Add key to functions dedup() and uniq()

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,16 +289,22 @@ Or using decorators:
         '1, -2, 3, -4, 5'
 
     dedup()
-        Deduplicate values
+        Deduplicate values, using the given key function if provided (or else
+        the identity)
 
         >>> [1,1,2,2,3,3,1,2,3] | dedup | as_list
         [1, 2, 3]
+        >>> [1,1,2,2,3,3,1,2,3] | dedup(key=lambda n:n % 2) | as_list
+        [1, 2]
 
     uniq()
-        Like dedup() but only deduplicate consecutive values.
+        Like dedup() but only deduplicate consecutive values, using the given
+        key function if provided (or else the identity)
 
         >>> [1,1,2,2,3,3,1,2,3] | uniq | as_list
         [1, 2, 3, 1, 2, 3]
+        >>> [1,1,2,2,3,3,1,2,3] | uniq(key=lambda n:n % 2) | as_list
+        [1, 2, 3, 2, 3]
 
     reverse
         Like Python's built-in "reversed" primitive.

--- a/pipe.py
+++ b/pipe.py
@@ -88,16 +88,17 @@ def skip(iterable, qte):
             qte -= 1
 
 @Pipe
-def dedup(iterable):
+def dedup(iterable, key=lambda x:x):
     """Only yield unique items. Use a set to keep track of duplicate data."""
     seen = set()
     for item in iterable:
-        if item not in seen:
-            seen.add(item)
+        dupkey = key(item)
+        if dupkey not in seen:
+            seen.add(dupkey)
             yield item
 
 @Pipe
-def uniq(iterable):
+def uniq(iterable, key=lambda x:x):
     """Deduplicate consecutive duplicate values."""
     iterator = iter(iterable)
     try:
@@ -105,10 +106,12 @@ def uniq(iterable):
     except StopIteration:
         return
     yield prev
+    prevkey = key(prev)
     for item in iterator:
-        if item != prev:
+        itemkey = key(item)
+        if itemkey != prevkey:
             yield item
-        prev = item
+        prevkey = itemkey
 
 @Pipe
 def all(iterable, pred):


### PR DESCRIPTION
Use case: If you create a dict by `dict([(1,"foo"), (2,"bar"),(1,"baz")])`, it will give you `{1: "baz", 2: "bar"}`. With the key function, we achieve the similar by

    [(1, "foo"), (2,"bar"), (1, "baz")] | reverse | dedup(key=lambda x:x[0])

Indeed, it is useful if we are manipulating a list of more complex objects.