### PR TITLE
Add into_iter helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ Or using decorators:
         >>> [[1, 2, 3], [4, 5, 6], [7, 8, 9]] | transpose
         [(1, 4, 7), (2, 5, 8), (3, 6, 9)]
 
+    into_iter()
+        Like 'select', but applies the conversion expression on the iterable
+        rather than on the items in it.
+        >>> [('a', 1), ('b', 2)] | as_dict | into_iter(lambda x: x.iteritems()) | select(lambda (k, v): v) | as_list
+        [1, 2]
+
 
 # Euler project samples
 

--- a/pipe.py
+++ b/pipe.py
@@ -29,7 +29,7 @@ __all__ = [
     'skip_while', 'aggregate', 'groupby', 'sort', 'reverse',
     'chain_with', 'islice', 'izip', 'passed', 'index', 'strip',
     'lstrip', 'rstrip', 'run_with', 't', 'to_type', 'transpose',
-    'dedup', 'uniq',
+    'dedup', 'uniq', 'into_iter',
 ]
 
 
@@ -60,6 +60,10 @@ class Pipe:
     def __call__(self, *args, **kwargs):
         return Pipe(lambda x: self.function(x, *args, **kwargs))
 
+
+@Pipe
+def into_iter(value, func):
+    return func(value)
 
 @Pipe
 def take(iterable, qte):


### PR DESCRIPTION
Hi,

Pipe is a great library. Thanks for creating it!

I wanted to be able to iterate over the items in a `dict` but there doesn't seem to be a way to do that in a single pipe expression. This PR adds a new helper `into_iter`(I couldn't come up with a better name: `map` fits, but it is also a builtin) which allows applying a function on the iterable object.

Edit: Tested this on Python 2 only.