### PR TITLE
Add path function

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ Or using decorators:
                 | concat(' / ')
         'Even : 1, 3, 5, 7, 9 / Odd : 2, 4, 6, 8'
 
+    path()
+        Retrieve the value at a given path.
+        >>> {'addr': {'country': 'Brazil'}} | path(['addr', 'country'])
+        'Brazil'
+
     sort()
         Like Python's built-in "sorted" primitive. Allows cmp (Python 2.x
         only), key, and reverse arguments. By default sorts using the

--- a/pipe.py
+++ b/pipe.py
@@ -32,6 +32,7 @@ __all__ = [
     "average",
     "count",
     "map",
+    "path",
     "max",
     "min",
     "as_dict",
@@ -393,6 +394,17 @@ def select(iterable, selector):
 
 
 map = select
+
+
+@Pipe
+def path(obj, steps, default=None):
+    value = obj.get(steps[0], default) if isinstance(obj, dict) else default
+    steps = steps[1:]
+
+    if not steps:
+        return value
+
+    return value | path(steps, default)
 
 
 @Pipe


### PR DESCRIPTION
I have been working in a called [pyf](https://github.com/sergiors/pyf) and used in production.

As asked in issue #38, there a function that I think be useful for everyone that use Pipe project.

Here is a real example where I have been used:
```python
docs = await es.search(index=index_name, body=s.to_dict())
docs = tuple(docs | path(['hits', 'hits'])
                  | map(itemgetter('_source')))
```