### PR TITLE
add terminators

### DIFF
--- a/pipe/__init__.py
+++ b/pipe/__init__.py
@@ -205,4 +205,4 @@ izip = Pipe(zip)
 if __name__ == "__main__":
     import doctest
 
-    doctest.testfile("README.md")
+    doctest.testfile("../README.md")

--- a/pipe/terminator.py
+++ b/pipe/terminator.py
@@ -1,0 +1,140 @@
+import builtins
+import functools
+import pipe
+
+from collections import deque
+
+
+class Terminator:
+    """
+    Terminate a pipeline, performing a final operation or returning a final result.
+
+    Unlike Pipe elements, Terminators do not necessarily return iterables, but rather final results of a pipeline.
+    Terminators can also perform final operations such as `foreach` and `reduce`.
+
+    Represent a termination to a Pipe :
+    Described as :
+        as_list = Terminator(lambda iterable: list(iterable))
+    then the following are equivalent :
+        list(range(10) | is_even)
+        range(10) | is_even > as_list
+
+    Or represent a terminating Function :
+        It's a function returning a Terminator
+    Described as :
+        join = Terminator(lambda iterable, sep: sep.join(iterable))
+    and used as :
+        range(10) | is_even > join("-")
+        # 0-2-4-6-8
+
+    Or represent a terminating operation :
+    Described as :
+        foreach = Terminator(lambda iterable, f: f(x) for x in iterable)
+    and used as :
+        range(10) | is_even > foreach(lambda x: print(x))
+    """
+
+    def __init__(self, function):
+        self.function = function
+        functools.update_wrapper(self, function)
+
+    def __lt__(self, other):
+        return self.function(other)
+
+    def __call__(self, *args, **kwargs):
+        return Terminator(
+            lambda iterable, *args2, **kwargs2: self.function(
+                iterable, *args, *args2, **kwargs, **kwargs2
+            )
+        )
+
+
+#######################
+# Collector Terminators
+#######################
+
+
+def _identity(x):
+    return x
+
+
+@Terminator
+def as_dict(iterable, key_func=_identity, value_func=_identity):
+    if key_func is _identity and value_func is _identity:
+        return dict(iterable)
+
+    return dict(iterable | pipe.map(lambda x: (key_func(x), value_func(x))))
+
+
+@Terminator
+def as_list(iterable):
+    return list(iterable)
+
+
+@Terminator
+def as_set(iterable, key_func=_identity):
+    if key_func is _identity:
+        return dict(iterable)
+
+    return set(iterable | pipe.map(lambda x: key_func(x)))
+
+
+#####################
+# General Terminators
+#####################
+
+
+@Terminator
+def foreach(iterable, f):
+    for item in iterable:
+        f(item)
+
+
+@Terminator
+def join(iterable, sep=""):
+    return sep.join(iterable)
+
+
+_initial_missing = object()
+
+
+@Terminator
+def reduce(iterable, accumulator, initial_value=_initial_missing):
+    if initial_value is _initial_missing:
+        return functools.reduce(accumulator, iterable)
+    return functools.reduce(accumulator, iterable, initial_value)
+
+
+#######################
+# Selecting Terminators
+#######################
+
+
+@Terminator
+def first(iterable):
+    return next(iter(iterable))
+
+
+@Terminator
+def last(iterable):
+    return deque(iterable, maxlen=1).pop()
+
+
+#####################
+# Numeric Terminators
+#####################
+
+
+@Terminator
+def max(iterable):
+    return builtins.max(iterable)
+
+
+@Terminator
+def min(iterable):
+    return builtins.min(iterable)
+
+
+@Terminator
+def sum(iterable):
+    return builtins.sum(iterable)

--- a/tests/test_terminator.py
+++ b/tests/test_terminator.py
@@ -1,0 +1,83 @@
+import pipe
+import pipe.terminator as term
+
+
+def test_as_dict():
+    data = ["banana", "grapefruit", "guava"]
+    expected = {"BANANA": 6, "GRAPEFRUIT": 10, "GUAVA": 5}
+    actual = data > term.as_dict(
+        key_func=lambda e: e.upper(),
+        value_func=lambda e: len(e),
+    )
+    assert isinstance(actual, dict)
+    assert actual == expected
+
+
+def test_as_list():
+    expected = ["abc", 6, {"key": "value"}]
+    actual = expected | pipe.take(3) > term.as_list
+    assert isinstance(actual, list)
+    assert actual == expected
+
+
+def test_as_set():
+    data = ["banana", "grapefruit", "guava"]
+    expected = {"BANANA", "GRAPEFRUIT", "GUAVA"}
+    actual = data > term.as_set(
+        key_func=lambda e: e.upper(),
+    )
+    assert isinstance(actual, set)
+    assert actual == expected
+
+
+def test_join():
+    actual = range(10) | pipe.filter(lambda x: x % 2 == 0) | pipe.map(str) > term.join("-")
+    assert actual == "0-2-4-6-8"
+
+
+def _foreach_func(actual, e):
+    actual[e.upper()] = len(e)
+
+
+def test_foreach():
+    data = ["banana", "grapefruit", "guava"]
+    expected = {"BANANA": 6, "GRAPEFRUIT": 10, "GUAVA": 5}
+    actual = {}
+    data > term.foreach(lambda e: _foreach_func(actual, e))
+    assert actual == expected
+
+
+def test_reduce():
+    actual = range(10) | pipe.filter(lambda e: e % 2 == 0) > term.reduce(lambda a, b: a + b)
+    assert actual == 20
+
+
+def test_reduce_with_initial():
+    data = ["banana", "grapefruit", "guava"]
+    actual = data > term.reduce(lambda acc, e: acc + len(e), 0)
+    assert actual == 21
+
+
+def test_first():
+    actual = ["a", "b", "c"] > term.first
+    assert actual == "a"
+
+
+def test_last():
+    actual = ["a", "b", "c"] > term.last
+    assert actual == "c"
+
+
+def test_max():
+    actual = [3, 7, -4, 0] > term.max
+    assert actual == 7
+
+
+def test_min():
+    actual = [3, 7, -4, 0] > term.min
+    assert actual == -4
+
+
+def test_sum():
+    actual = [3, 7, -4, 0] > term.sum
+    assert actual == 6


### PR DESCRIPTION
This change introduces Terminators as described in [this comment](https://github.com/JulienPalard/Pipe/issues/74#issuecomment-1436481100) that I made on issue #74.

I discovered that the `>` operator can be used for terminators, as it has lower precedence than `|` so it will properly terminate the pipeline. I chose to use a separate operator for terminators in order to reduce misunderstandings as discussed on #74. I also placed terminators in their own package to further differentiate them, so users will have more opportunities to understand that they are used differently.

I've also implemented a whole bunch of common terminators I see used in other languages, especially java (my main language).

I also just remembered the README needs to be updated to explain terminators, too. I'm happy to make that addition if the concept is approved.

P.S.
I'm not the most skilled python user, so I may have done the module handling and `__init__` file stuff wrong ;_;. But if so I'm happy to do whatever's needed to fix it!