### PR TITLE
Pipe composition

### DIFF
--- a/pipe.py
+++ b/pipe.py
@@ -38,6 +38,9 @@ class Pipe:
         )
         functools.update_wrapper(self, function)
 
+    def __or__(self, other):
+        return Pipe(lambda iterable: self.function(iterable) | other)
+
     def __ror__(self, other):
         return self.function(other)
 

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -39,3 +39,8 @@ def test_enumerate():
     data = [4, "abc", {"key": "value"}]
     expected = [(5, 4), (6, "abc"), (7, {"key": "value"})]
     assert list(data | pipe.enumerate(start=5)) == expected
+
+
+def test_composition():
+    p = pipe.where(lambda x: not x % 2) | pipe.take(5)
+    assert list(range(100) | p) == [0, 2, 4, 6, 8]


### PR DESCRIPTION
Allow for composable pipes. For example: `p = where(lambda x: x < 5) | head` is now a valid expression that will return a pipe composed of both functions. 