### PR TITLE
coverage: Add static context (CoverageWarning: No contexts were measured).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ lint.extend-select = ["C", "D", "FURB", "I", "N", "PL", "PTH", "SIM"]
 lint.extend-ignore = [
     "D100", # Missing docstring in public module
     "D101", # Missing docstring in public class
-    "D102", # 
+    "D102", #
     "D103", # Missing docstring in public function
     "D105",
 ]
@@ -76,6 +76,8 @@ commands = [
     [
         "coverage",
         "run",
+        "--context",
+        "{env_name}",
         "-m",
         "pytest",
         "--doctest-glob=README.md",


### PR DESCRIPTION
@AdrianCert was this missing?

It avoids a warning at the end of the tox run:

```
/home/mdk/src/mdk/pipe/.tox/cov-report/lib/python3.13/site-packages/coverage/html.py:124: CoverageWarning: No contexts were measured
  self.coverage._warn("No contexts were measured")
```